### PR TITLE
test_driveR2: Add if-else statement that loads in data based on AnVIL or SciServer environment

### DIFF
--- a/tutorials/test_driveR2/test_driveR.Rmd
+++ b/tutorials/test_driveR2/test_driveR.Rmd
@@ -47,7 +47,7 @@ if (file.exists(file_path)) {
 
 df_long <- pivot_longer( df, 3:9, names_to="region", values_to="count" )
 ```
-```
+
 
 
 <!---

--- a/tutorials/test_driveR2/test_driveR.Rmd
+++ b/tutorials/test_driveR2/test_driveR.Rmd
@@ -30,14 +30,23 @@ prerequisites: "None"
 ---
 
 ```{r setup, include=FALSE}
-remotes::install_github("C-MOOR/testdriveRData")
-library(testdriveRData)
 library(learnr)
 library( "tidyverse" )
 knitr::opts_chunk$set(echo = FALSE)
 
-df <- testdriveRData
+#First, check if we are on SciServer by seeing if the file path to test-driveR on SciServer is available.
+file_path <- "/home/idies/workspace/c_moor_data/test-driveR/test-driveR.tsv"
+if (file.exists(file_path)) {
+  #If available, load in the file test-driveR.tsv to an object called df
+  df <- read_tsv("/home/idies/workspace/c_moor_data/test-driveR/test-driveR.tsv")
+} else {
+  #If not, assume we are on AnVIL and load in the data through the package testdriveRData and load the object testdriveRData (which has the same content as test-driveR.tsv) to the object df. We only load testdriveRData on AnVIL because the AnVIL enivronment has the package testdriveRData installed through the startup script
+  library("testdriveRData")
+  df <- testdriveRData
+}
+
 df_long <- pivot_longer( df, 3:9, names_to="region", values_to="count" )
+```
 ```
 
 


### PR DESCRIPTION
1) Check if the file path for SciServer exists (will tell us we are on SciServer) and if it exists, load test-driveR.tsv into the object df

2) If the file path does not exist, assume we are on AnVIL and the environment will be installed with testdriveRData R package through the startup script

3) On AnVIL, load testdriveRData object from testdriveRData R package into the object df

4) Removed install_github("C-MOOR/testdriveRData") (doesn't work)

5) Moved library(testdriveRData) to only be used when on AnVIL, as SciServer environment should not have testdriveRData package installed